### PR TITLE
42 editing of petitions not working

### DIFF
--- a/api/src/Entity/Petitioning/Petition.php
+++ b/api/src/Entity/Petitioning/Petition.php
@@ -16,7 +16,7 @@ use Symfony\Component\Serializer\Annotation\Groups;
     attributes: ['security' => "is_granted('ROLE_USER')", "pagination_enabled" => false],
     itemOperations: [
         "get",
-        "put" => ['security' => "is_granted('ROLE_ADMIN') or (object.createUser == user)"]
+        "put" => ['security_post_denormalize' => "is_granted('PETITION_CAN_UPDATE',previous_object)"]
     ]
  )
  ]

--- a/api/src/Security/Voter/PetitionCanEditVoter.php
+++ b/api/src/Security/Voter/PetitionCanEditVoter.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Security\Voter;
+
+use App\Entity\Petitioning\Petition;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+class PetitionCanEditVoter extends Voter
+{
+    protected function supports(string $attribute, $subject): bool
+    {
+        // replace with your own logic
+        // https://symfony.com/doc/current/security/voters.html
+        return in_array($attribute, ['PETITION_CAN_UPDATE'])
+            && $subject instanceof Petition;
+    }
+
+    /**
+     * Undocumented function
+     *
+     * @param string $attribute
+     * @param Petition $subject
+     * @param TokenInterface $token
+     * @return boolean
+     */
+    protected function voteOnAttribute(string $attribute, $subject, TokenInterface $token): bool
+    {
+        $user = $token->getUser();
+        // if the user is anonymous, do not grant access
+        if (!$user instanceof UserInterface) {
+            return false;
+        }
+
+        // ... (check conditions and return true to grant permission) ...
+        switch ($attribute) {
+            case 'PETITION_CAN_UPDATE':
+                return $subject->getCreateUser() == $user;
+                break;
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
The problem was that the security test in the attribute was not working as intended

The issue was resolved by changing the security process to use a voter which is verifying the last create user from the database against the currently logged in user. This also prevents users from hijacking petitions by changing the create user in the put request

This patch also removed admins from the table to be able to always change petitions (which was actually never meant to be possible)